### PR TITLE
Feature: Pageable sortField, sortDirection, size, page 매핑되도록 Pageable resolver 커스텀

### DIFF
--- a/src/main/java/com/project/hrbank/backup/controller/BackupController.java
+++ b/src/main/java/com/project/hrbank/backup/controller/BackupController.java
@@ -3,8 +3,6 @@ package com.project.hrbank.backup.controller;
 import java.time.LocalDateTime;
 
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -34,12 +32,7 @@ public class BackupController {
 		@RequestParam(required = false) Status status,
 		@RequestParam(required = false, name = "startedAtFrom") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startedAtFrom,
 		@RequestParam(required = false, name = "startedAtTo") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startedAtTo,
-		@PageableDefault(
-			size = 30,
-			page = 0,
-			sort = "startedAt",
-			direction = Sort.Direction.DESC
-		) Pageable pageable
+		Pageable pageable
 	) {
 
 		CursorPageResponseBackupDto backupDto = backupService.findAll(cursor, status, startedAtFrom, startedAtTo, pageable);

--- a/src/main/java/com/project/hrbank/backup/provider/EmployeesLogCsvFileProvider.java
+++ b/src/main/java/com/project/hrbank/backup/provider/EmployeesLogCsvFileProvider.java
@@ -26,9 +26,9 @@ import com.project.hrbank.repository.EmployeeRepository;
 @Component
 public class EmployeesLogCsvFileProvider {
 
-	public static final DateTimeFormatter TIME_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss");
-	public static final String BACKUP_FILE_NAME = "backup_employee";
-	public static final String CSV_HEADER_CONTENT = "ID,직원번호,이름,부서,직급,입사일,상태";
+	private static final DateTimeFormatter TIME_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss");
+	private static final String BACKUP_FILE_NAME = "backup_employee";
+	private static final String CSV_HEADER_CONTENT = "ID,직원번호,이름,부서,직급,입사일,상태";
 
 	private final Path DIRECTORY;
 	private final EmployeeRepository employeeRepository;

--- a/src/main/java/com/project/hrbank/backup/provider/EmployeesLogCsvFileProvider.java
+++ b/src/main/java/com/project/hrbank/backup/provider/EmployeesLogCsvFileProvider.java
@@ -76,7 +76,7 @@ public class EmployeesLogCsvFileProvider {
 
 				page++;
 			} while (employeePage.hasNext());
-			
+
 			long fileSize = Files.size(employeesLogFilePath);
 			FileEntity fileEntity = new FileEntity(fileName, FileExtension.CSV.getDescription(), fileSize, employeesLogFilePath.getParent().toString());
 			return Optional.of(fileEntity);

--- a/src/main/java/com/project/hrbank/backup/service/BackupService.java
+++ b/src/main/java/com/project/hrbank/backup/service/BackupService.java
@@ -2,7 +2,6 @@ package com.project.hrbank.backup.service;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
@@ -120,7 +119,7 @@ public class BackupService {
 		return backupRepository.findLastBackup()
 			.stream()
 			.findFirst()
-			.orElseThrow(() -> new NoSuchElementException("Not found Backup"));
+			.orElse(null);
 	}
 
 	private BackupDto toDto(Backup backup) {

--- a/src/main/java/com/project/hrbank/config/JpaAuditing/JpaAuditingConfiguration.java
+++ b/src/main/java/com/project/hrbank/config/JpaAuditing/JpaAuditingConfiguration.java
@@ -1,4 +1,4 @@
-package com.project.hrbank.config;
+package com.project.hrbank.config.JpaAuditing;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;

--- a/src/main/java/com/project/hrbank/config/WebConfiguration.java
+++ b/src/main/java/com/project/hrbank/config/WebConfiguration.java
@@ -1,0 +1,24 @@
+package com.project.hrbank.config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.project.hrbank.config.paging.CustomPageableArgumentResolver;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfiguration implements WebMvcConfigurer {
+
+	private final CustomPageableArgumentResolver pageableArgumentResolver;
+
+	@Override
+	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+		resolvers.add(pageableArgumentResolver);
+	}
+
+}

--- a/src/main/java/com/project/hrbank/config/paging/CustomPageableArgumentResolver.java
+++ b/src/main/java/com/project/hrbank/config/paging/CustomPageableArgumentResolver.java
@@ -1,0 +1,67 @@
+package com.project.hrbank.config.paging;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class CustomPageableArgumentResolver extends PageableHandlerMethodArgumentResolver {
+
+	public static final String SORT_FIELD_KEY = "sortField";
+
+	@Override
+	public Pageable resolveArgument(
+		MethodParameter methodParameter,
+		ModelAndViewContainer mavContainer,
+		NativeWebRequest webRequest,
+		WebDataBinderFactory binderFactory
+	) {
+
+		String sortFieldValue = getSortFieldValue(webRequest);
+		Sort.Direction sortDirectionValue = getSortDirectionValue(webRequest);
+		int pageValue = getIntegerOrDefault(webRequest.getParameter("page"), 0);
+		int sizeValue = getIntegerOrDefault(webRequest.getParameter("page"), 30);
+
+		return PageRequest.of(pageValue, sizeValue, Sort.by(sortDirectionValue, sortFieldValue));
+	}
+
+	private int getIntegerOrDefault(String value, int defaultValue) {
+		if (value == null || value.isBlank()) {
+			return defaultValue;
+		}
+
+		try {
+			return Integer.parseInt(value);
+		} catch (NumberFormatException exception) {
+			return defaultValue;
+		}
+	}
+
+	private String getSortFieldValue(NativeWebRequest webRequest) {
+		String sortField = webRequest.getParameter(SORT_FIELD_KEY);
+		if (sortField == null || sortField.isBlank()) {
+			return "startedAt";
+		}
+		return sortField;
+	}
+
+	private Sort.Direction getSortDirectionValue(NativeWebRequest webRequest) {
+		String sortDirection = webRequest.getParameter("sortDirection");
+		if (sortDirection == null || sortDirection.isBlank()) {
+			return Sort.Direction.DESC;
+		}
+
+		try {
+			return Sort.Direction.fromString(sortDirection);
+		} catch (IllegalArgumentException exception) {
+			return Sort.Direction.DESC;
+		}
+	}
+
+}

--- a/src/main/java/com/project/hrbank/config/paging/CustomPageableArgumentResolver.java
+++ b/src/main/java/com/project/hrbank/config/paging/CustomPageableArgumentResolver.java
@@ -13,10 +13,10 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 @Component
 public class CustomPageableArgumentResolver extends PageableHandlerMethodArgumentResolver {
 
-	public static final String PAGE = "page";
-	public static final String SIZE = "size";
-	public static final String SORT_FIELD_KEY = "sortField";
-	public static final String SORT_DIRECTION_KEY = "sortDirection";
+	private static final String PAGE = "page";
+	private static final String SIZE = "size";
+	private static final String SORT_FIELD_KEY = "sortField";
+	private static final String SORT_DIRECTION_KEY = "sortDirection";
 
 	@Override
 	public Pageable resolveArgument(

--- a/src/main/java/com/project/hrbank/config/paging/CustomPageableArgumentResolver.java
+++ b/src/main/java/com/project/hrbank/config/paging/CustomPageableArgumentResolver.java
@@ -13,7 +13,10 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 @Component
 public class CustomPageableArgumentResolver extends PageableHandlerMethodArgumentResolver {
 
+	public static final String PAGE = "page";
+	public static final String SIZE = "size";
 	public static final String SORT_FIELD_KEY = "sortField";
+	public static final String SORT_DIRECTION_KEY = "sortDirection";
 
 	@Override
 	public Pageable resolveArgument(
@@ -25,8 +28,8 @@ public class CustomPageableArgumentResolver extends PageableHandlerMethodArgumen
 
 		String sortFieldValue = getSortFieldValue(webRequest);
 		Sort.Direction sortDirectionValue = getSortDirectionValue(webRequest);
-		int pageValue = getIntegerOrDefault(webRequest.getParameter("page"), 0);
-		int sizeValue = getIntegerOrDefault(webRequest.getParameter("page"), 30);
+		int pageValue = getIntegerOrDefault(webRequest.getParameter(PAGE), 0);
+		int sizeValue = getIntegerOrDefault(webRequest.getParameter(SIZE), 30);
 
 		return PageRequest.of(pageValue, sizeValue, Sort.by(sortDirectionValue, sortFieldValue));
 	}
@@ -52,7 +55,7 @@ public class CustomPageableArgumentResolver extends PageableHandlerMethodArgumen
 	}
 
 	private Sort.Direction getSortDirectionValue(NativeWebRequest webRequest) {
-		String sortDirection = webRequest.getParameter("sortDirection");
+		String sortDirection = webRequest.getParameter(SORT_DIRECTION_KEY);
 		if (sortDirection == null || sortDirection.isBlank()) {
 			return Sort.Direction.DESC;
 		}

--- a/src/main/java/com/project/hrbank/controller/EmployeeController.java
+++ b/src/main/java/com/project/hrbank/controller/EmployeeController.java
@@ -1,20 +1,27 @@
 package com.project.hrbank.controller;
 
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
 import com.project.hrbank.dto.request.EmployeeRequestDto;
 import com.project.hrbank.dto.response.EmployeeResponseDto;
 import com.project.hrbank.entity.EmployeeStatus;
 import com.project.hrbank.service.EmployeeService;
 
-import lombok.RequiredArgsConstructor;
-
-import org.springframework.data.domain.Page;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
-
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/api/employees")
@@ -31,7 +38,6 @@ public class EmployeeController {
 		EmployeeResponseDto responseDto = employeeService.registerEmployee(requestDto, profileImage);
 		return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
 	}
-
 
 	@GetMapping
 	public ResponseEntity<Page<EmployeeResponseDto>> getEmployees(

--- a/src/main/java/com/project/hrbank/dto/request/EmployeeRequestDto.java
+++ b/src/main/java/com/project/hrbank/dto/request/EmployeeRequestDto.java
@@ -2,14 +2,8 @@ package com.project.hrbank.dto.request;
 
 import java.time.LocalDate;
 
-import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.web.multipart.MultipartFile;
-
 import com.project.hrbank.entity.EmployeeStatus;
 
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/project/hrbank/entity/Employee.java
+++ b/src/main/java/com/project/hrbank/entity/Employee.java
@@ -3,8 +3,6 @@ package com.project.hrbank.entity;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
-import org.hibernate.annotations.DynamicUpdate;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;

--- a/src/main/java/com/project/hrbank/file/controller/FileController.java
+++ b/src/main/java/com/project/hrbank/file/controller/FileController.java
@@ -15,7 +15,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
-import com.project.hrbank.file.dto.FileDto;
 import com.project.hrbank.file.entity.FileEntity;
 import com.project.hrbank.file.service.FileService;
 import com.project.hrbank.file.storage.FileStorage;
@@ -29,7 +28,6 @@ public class FileController {
 
 	private final FileService fileService;
 	private final FileStorage fileStorage;
-
 
 	@GetMapping("/{id}/download")
 	public ResponseEntity<?> download(@PathVariable Long id) {

--- a/src/main/java/com/project/hrbank/file/converter/FileConverter.java
+++ b/src/main/java/com/project/hrbank/file/converter/FileConverter.java
@@ -8,8 +8,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
 
 import org.springframework.web.multipart.MultipartFile;
 

--- a/src/main/java/com/project/hrbank/file/handler/impl/CsvFileHandler.java
+++ b/src/main/java/com/project/hrbank/file/handler/impl/CsvFileHandler.java
@@ -28,7 +28,7 @@ public class CsvFileHandler implements FileHandler {
 	}
 
 	@Override
-	public byte[] processFileData(String fileName ,byte[] fileData) throws IOException {
+	public byte[] processFileData(String fileName, byte[] fileData) throws IOException {
 		Path filePath = Paths.get(CSV_STORAGE_PATH + fileName);
 		Files.createDirectories(filePath.getParent());
 

--- a/src/main/java/com/project/hrbank/file/handler/impl/LogFileHandler.java
+++ b/src/main/java/com/project/hrbank/file/handler/impl/LogFileHandler.java
@@ -30,7 +30,7 @@ public class LogFileHandler implements FileHandler {
 	}
 
 	@Override
-	public byte[] processFileData(String fileName , byte[] fileData) throws IOException {
+	public byte[] processFileData(String fileName, byte[] fileData) throws IOException {
 		Path filePath = Paths.get(LOG_STORAGE_PATH + fileName);
 		Files.createDirectories(filePath.getParent());
 

--- a/src/main/java/com/project/hrbank/file/service/FileServiceImpl.java
+++ b/src/main/java/com/project/hrbank/file/service/FileServiceImpl.java
@@ -41,7 +41,7 @@ public class FileServiceImpl implements FileService {
 
 	@Override
 	public FileEntity saveFileData(String fileName, byte[] fileData, String contentType) throws IOException {
-		if(fileData == null || fileData.length == 0){
+		if (fileData == null || fileData.length == 0) {
 			throw new IllegalArgumentException("파일 데이터가 비어 있습니다.");
 		}
 		FileHandler fileHandler = fileHandlerFactory.getFileHandler(fileName);

--- a/src/main/java/com/project/hrbank/file/storage/FileStorage.java
+++ b/src/main/java/com/project/hrbank/file/storage/FileStorage.java
@@ -2,7 +2,6 @@ package com.project.hrbank.file.storage;
 
 import java.io.InputStream;
 
-import com.project.hrbank.file.dto.FileDto;
 import com.project.hrbank.file.entity.FileEntity;
 
 public interface FileStorage {

--- a/src/main/java/com/project/hrbank/file/storage/LocalFileStorage.java
+++ b/src/main/java/com/project/hrbank/file/storage/LocalFileStorage.java
@@ -7,14 +7,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import org.springframework.core.io.InputStreamResource;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import com.project.hrbank.file.FileHandlerFactory;
-import com.project.hrbank.file.dto.FileDto;
 import com.project.hrbank.file.entity.FileEntity;
 import com.project.hrbank.file.repository.FileRepository;
 
@@ -100,7 +95,6 @@ public class LocalFileStorage implements FileStorage {
 			throw new RuntimeException("파일 스트림 생성 실패", e);
 		}
 	}
-
 
 	@Override
 	public boolean delete(Long id) {

--- a/src/main/java/com/project/hrbank/repository/EmployeeLogRepository.java
+++ b/src/main/java/com/project/hrbank/repository/EmployeeLogRepository.java
@@ -20,7 +20,7 @@ public interface EmployeeLogRepository extends JpaRepository<EmployeeLogs, Long>
 		"AND (COALESCE(:atFrom, e.changedAt) = e.changedAt OR COALESCE(:atTo, e.changedAt) = e.changedAt OR e.changedAt BETWEEN :atFrom AND :atTo) "
 		+
 		"AND (:employeeNumber IS NULL OR e.employeeNumber LIKE CONCAT('%', :employeeNumber, '%')) " +
-		"AND (:memo IS NULL OR e.memo LIKE CONCAT('%', :memo, '%')) " +
+		"AND (:memo IS NULL OR e.memo IS NULL OR e.memo LIKE CONCAT('%', :memo, '%')) " +
 		"AND (:ipAddress IS NULL OR e.ipAddress LIKE CONCAT('%', :ipAddress, '%')) " +
 		"AND (:type IS NULL OR e.type LIKE CONCAT('%', :type, '%'))")
 	Slice<EmployeeLogs> findAll(

--- a/src/main/java/com/project/hrbank/repository/EmployeeRepository.java
+++ b/src/main/java/com/project/hrbank/repository/EmployeeRepository.java
@@ -2,14 +2,14 @@ package com.project.hrbank.repository;
 
 import java.time.LocalDate;
 
-import com.project.hrbank.entity.Employee;
-import com.project.hrbank.entity.EmployeeStatus;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import com.project.hrbank.entity.Employee;
+import com.project.hrbank.entity.EmployeeStatus;
 
 public interface EmployeeRepository extends JpaRepository<Employee, Long> {
 

--- a/src/main/java/com/project/hrbank/service/EmployeeService.java
+++ b/src/main/java/com/project/hrbank/service/EmployeeService.java
@@ -1,12 +1,11 @@
 package com.project.hrbank.service;
 
+import org.springframework.data.domain.Page;
+import org.springframework.web.multipart.MultipartFile;
+
 import com.project.hrbank.dto.request.EmployeeRequestDto;
 import com.project.hrbank.dto.response.EmployeeResponseDto;
 import com.project.hrbank.entity.EmployeeStatus;
-
-import org.springframework.data.domain.Page;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
 public interface EmployeeService {
 	Page<EmployeeResponseDto> getEmployees(String nameOrEmail, String departmentName, String position,
@@ -16,6 +15,7 @@ public interface EmployeeService {
 	EmployeeResponseDto getEmployeeById(Long id);
 
 	EmployeeResponseDto registerEmployee(EmployeeRequestDto requestDto, MultipartFile profileImage);
+
 	long countActiveEmployees();
 
 	EmployeeResponseDto updateEmployee(Long id, EmployeeRequestDto dto, MultipartFile profileImage);

--- a/src/main/java/com/project/hrbank/service/EmployeeServiceImpl.java
+++ b/src/main/java/com/project/hrbank/service/EmployeeServiceImpl.java
@@ -9,18 +9,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.project.hrbank.dto.request.EmployeeRequestDto;
-import com.project.hrbank.dto.response.EmployeeResponseDto;
-import com.project.hrbank.entity.Employee;
-import com.project.hrbank.entity.EmployeeLogs;
-import com.project.hrbank.entity.EmployeeStatus;
-import com.project.hrbank.repository.EmployeeLogRepository;
-import com.project.hrbank.repository.EmployeeRepository;
-
-import lombok.RequiredArgsConstructor;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
@@ -31,6 +19,17 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.hrbank.dto.request.EmployeeRequestDto;
+import com.project.hrbank.dto.response.EmployeeResponseDto;
+import com.project.hrbank.entity.Employee;
+import com.project.hrbank.entity.EmployeeStatus;
+import com.project.hrbank.repository.EmployeeLogRepository;
+import com.project.hrbank.repository.EmployeeRepository;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/project/hrbank/service/EmployeeServiceImpl.java
+++ b/src/main/java/com/project/hrbank/service/EmployeeServiceImpl.java
@@ -9,19 +9,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.project.hrbank.dto.DepartmentDto;
-import com.project.hrbank.dto.request.EmployeeRequestDto;
-import com.project.hrbank.dto.response.EmployeeResponseDto;
-import com.project.hrbank.entity.Employee;
-import com.project.hrbank.entity.EmployeeLogs;
-import com.project.hrbank.entity.EmployeeStatus;
-import com.project.hrbank.repository.EmployeeLogRepository;
-import com.project.hrbank.repository.EmployeeRepository;
-
-import lombok.RequiredArgsConstructor;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
@@ -32,6 +19,18 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.hrbank.dto.DepartmentDto;
+import com.project.hrbank.dto.request.EmployeeRequestDto;
+import com.project.hrbank.dto.response.EmployeeResponseDto;
+import com.project.hrbank.entity.Employee;
+import com.project.hrbank.entity.EmployeeStatus;
+import com.project.hrbank.repository.EmployeeRepository;
+import com.project.hrbank.util.IpUtils;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
@@ -250,17 +249,17 @@ public class EmployeeServiceImpl implements EmployeeService {
 			logger.info("로그 출력: {}", jsonString);
 
 			String sql = """
-            INSERT INTO employee_change_logs 
-                (type, changed_value, ip, employee_number, changed_at, memo)
-            VALUES 
-                (?, ?::jsonb, ?, ?, ?, ?)
-            """;
+				INSERT INTO employee_change_logs 
+				    (type, changed_value, ip, employee_number, changed_at, memo)
+				VALUES 
+				    (?, ?::jsonb, ?, ?, ?, ?)
+				""";
 
 			jdbcTemplate.update(
 				sql,
 				type,
 				jsonString,
-				"127.0.0.1",
+				IpUtils.getClientIp(),
 				employeeNumber,
 				LocalDateTime.now(),
 				memo

--- a/src/main/java/com/project/hrbank/util/IpUtils.java
+++ b/src/main/java/com/project/hrbank/util/IpUtils.java
@@ -1,0 +1,44 @@
+package com.project.hrbank.util;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+@Component
+public class IpUtils {
+	public static String getClientIp() {
+
+		String clientIp = "";
+		HttpServletRequest request = ((ServletRequestAttributes)RequestContextHolder.currentRequestAttributes()).getRequest();
+		clientIp = request.getHeader("X-Forwarded-For");
+
+		if (clientIp == null || clientIp.length() == 0 || "unknown".equalsIgnoreCase(clientIp)) {
+			clientIp = request.getHeader("Proxy-Client-IP");
+		}
+		if (clientIp == null || clientIp.length() == 0 || "unknown".equalsIgnoreCase(clientIp)) {
+			clientIp = request.getHeader("WL-Proxy-Client-IP");
+		}
+		if (clientIp == null || clientIp.length() == 0 || "unknown".equalsIgnoreCase(clientIp)) {
+			clientIp = request.getHeader("HTTP_CLIENT_IP");
+		}
+		if (clientIp == null || clientIp.length() == 0 || "unknown".equalsIgnoreCase(clientIp)) {
+			clientIp = request.getHeader("HTTP_X_FORWARDED_FOR");
+		}
+		if (clientIp == null || clientIp.length() == 0 || "unknown".equalsIgnoreCase(clientIp)) {
+			clientIp = request.getHeader("X-Real-IP");
+		}
+		if (clientIp == null || clientIp.length() == 0 || "unknown".equalsIgnoreCase(clientIp)) {
+			clientIp = request.getHeader("X-RealIP");
+		}
+		if (clientIp == null || clientIp.length() == 0 || "unknown".equalsIgnoreCase(clientIp)) {
+			clientIp = request.getHeader("REMOTE_ADDR");
+		}
+		if (clientIp == null || clientIp.length() == 0 || "unknown".equalsIgnoreCase(clientIp)) {
+			clientIp = request.getRemoteAddr();
+		}
+		System.out.println("Client IP ::" + clientIp);
+		return clientIp;
+	}
+}

--- a/src/test/java/com/project/hrbank/backup/DatabaseConnectionTest.java
+++ b/src/test/java/com/project/hrbank/backup/DatabaseConnectionTest.java
@@ -15,7 +15,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 public class DatabaseConnectionTest {
 
-	public static final String DATABASE_NAME = "hrbank";
+	private static final String DATABASE_NAME = "hrbank";
 	@Autowired
 	private DataSource dataSource;
 


### PR DESCRIPTION

Resolves : #42 

공통적으로 사용되는 정렬 조건이 front 에서 보내는 필드명이 기본 필드명과 달라 매핑이되지 않던 부분이 발생

`PageableHandlerMethodArgumentResolver` 를 상속받아 공통으로 매핑될 수 있도록 커스텀

`page`, `size`, `sortField`, `sortDirection` 필드를 쿼리파라미터에서 가지고와서 기본값과 value를 가지고 오도록 커스텀

## PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## Checklist before merging
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
